### PR TITLE
AVM: Track Scratch Slot Types

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -252,12 +252,18 @@ type OpStream struct {
 // newOpStream constructs OpStream instances ready to invoke assemble. A new
 // OpStream must be used for each call to assemble().
 func newOpStream(version uint64) OpStream {
-	return OpStream{
+	o := OpStream{
 		labels:       make(map[string]int),
 		OffsetToLine: make(map[int]int),
 		typeTracking: true,
 		Version:      version,
 	}
+
+	for i, _ := range o.known.scratchSpace {
+		o.known.scratchSpace[i] = StackUint64
+	}
+
+	return o
 }
 
 // ProgramKnowledge tracks statically known information as we assemble
@@ -1355,9 +1361,6 @@ func (ops *OpStream) assemble(text string) error {
 		return ops.errorf("Can not assemble version %d", ops.Version)
 	}
 	scanner := bufio.NewScanner(fin)
-	for i := range ops.known.scratchSpace {
-		ops.known.scratchSpace[i] = StackUint64
-	}
 	for scanner.Scan() {
 		ops.sourceLine++
 		line := scanner.Text()

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -259,7 +259,7 @@ func newOpStream(version uint64) OpStream {
 		Version:      version,
 	}
 
-	for i, _ := range o.known.scratchSpace {
+	for i := range o.known.scratchSpace {
 		o.known.scratchSpace[i] = StackUint64
 	}
 

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -314,7 +314,7 @@ func (pgm *ProgramKnowledge) reset() {
 	pgm.stack = nil
 	pgm.bottom = StackAny
 	pgm.deadcode = false
-	for i, _ := range pgm.scratchSpace {
+	for i := range pgm.scratchSpace {
 		pgm.scratchSpace[i] = StackAny
 	}
 }
@@ -1149,7 +1149,7 @@ func typeStore(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
 func typeStores(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
 	top := len(pgm.stack) - 1
 	if top >= 0 {
-		for i, _ := range pgm.scratchSpace {
+		for i := range pgm.scratchSpace {
 			if pgm.scratchSpace[i] != pgm.stack[top] {
 				pgm.scratchSpace[i] = StackAny
 			}
@@ -1360,7 +1360,7 @@ func (ops *OpStream) assemble(text string) error {
 		return ops.errorf("Can not assemble version %d", ops.Version)
 	}
 	scanner := bufio.NewScanner(fin)
-	for i, _ := range ops.known.scratchSpace {
+	for i := range ops.known.scratchSpace {
 		ops.known.scratchSpace[i] = StackUint64
 	}
 	for scanner.Scan() {

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -974,8 +974,8 @@ func asmDefault(ops *OpStream, spec *OpSpec, args []string) error {
 	return nil
 }
 
-// Interprets the arg at index argIndex as byte-long uint immediate
-func getUintImm(args []string, argIndex int) (byte, bool) {
+// Interprets the arg at index argIndex as byte-long immediate
+func getByteImm(args []string, argIndex int) (byte, bool) {
 	if len(args) <= argIndex {
 		return 0, false
 	}
@@ -1000,7 +1000,7 @@ func typeSwap(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
 }
 
 func typeDig(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
-	n, ok := getUintImm(args, 0)
+	n, ok := getByteImm(args, 0)
 	if !ok {
 		return nil, nil
 	}
@@ -1070,7 +1070,7 @@ func typeSetBit(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
 }
 
 func typeCover(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
-	n, ok := getUintImm(args, 0)
+	n, ok := getByteImm(args, 0)
 	if !ok {
 		return nil, nil
 	}
@@ -1098,7 +1098,7 @@ func typeCover(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
 }
 
 func typeUncover(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
-	n, ok := getUintImm(args, 0)
+	n, ok := getByteImm(args, 0)
 	if !ok {
 		return nil, nil
 	}
@@ -1134,7 +1134,7 @@ func typeTxField(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) 
 }
 
 func typeStore(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
-	scratchIndex, ok := getUintImm(args, 0)
+	scratchIndex, ok := getByteImm(args, 0)
 	if !ok {
 		return nil, nil
 	}
@@ -1160,7 +1160,7 @@ func typeStores(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
 }
 
 func typeLoad(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
-	scratchIndex, ok := getUintImm(args, 0)
+	scratchIndex, ok := getByteImm(args, 0)
 	if !ok {
 		return nil, nil
 	}

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1143,6 +1143,18 @@ func typeStore(pgm ProgramKnowledge, args []string) (StackTypes, StackTypes) {
 	return nil, nil
 }
 
+func typeStores(pgm ProgramKnowledge, args []string) (StackTypes, StackTypes) {
+	second := len(pgm.stack) - 2
+	if second >= 0 {
+		for i, _ := range pgm.scratchSpace {
+			if pgm.scratchSpace[i] != pgm.stack[second] {
+				pgm.scratchSpace[i] = StackAny
+			}
+		}
+	}
+	return nil, nil
+}
+
 func typeLoad(pgm ProgramKnowledge, args []string) (StackTypes, StackTypes) {
 	if len(args) == 0 {
 		return nil, nil
@@ -1156,6 +1168,16 @@ func typeLoad(pgm ProgramKnowledge, args []string) (StackTypes, StackTypes) {
 		return nil, nil
 	}
 	return nil, StackTypes{pgm.scratchSpace[scratchIndex]}
+}
+
+func typeLoads(pgm ProgramKnowledge, args []string) (StackTypes, StackTypes) {
+	scratchType := pgm.scratchSpace[0]
+	for _, item := range pgm.scratchSpace {
+		if item != scratchType {
+			return nil, nil
+		}
+	}
+	return nil, StackTypes{scratchType}
 }
 
 // keywords or "pseudo-ops" handle parsing and assembling special asm language
@@ -1335,6 +1357,9 @@ func (ops *OpStream) assemble(text string) error {
 		return ops.errorf("Can not assemble version %d", ops.Version)
 	}
 	scanner := bufio.NewScanner(fin)
+	for i, _ := range ops.known.scratchSpace {
+		ops.known.scratchSpace[i] = StackAny
+	}
 	for scanner.Scan() {
 		ops.sourceLine++
 		line := scanner.Text()

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -974,6 +974,17 @@ func asmDefault(ops *OpStream, spec *OpSpec, args []string) error {
 	return nil
 }
 
+func getUintImm(args []string) (n uint64, errored bool) {
+	if len(args) == 0 {
+		return 0, true
+	}
+	n, err := strconv.ParseUint(args[0], 0, 8)
+	if err != nil {
+		return 0, true
+	}
+	return n, false
+}
+
 func typeSwap(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
 	topTwo := StackTypes{StackAny, StackAny}
 	top := len(pgm.stack) - 1
@@ -988,11 +999,8 @@ func typeSwap(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
 }
 
 func typeDig(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
-	if len(args) == 0 {
-		return nil, nil
-	}
-	n, err := strconv.ParseUint(args[0], 0, 64)
-	if err != nil {
+	n, errored := getUintImm(args)
+	if errored {
 		return nil, nil
 	}
 	depth := int(n) + 1
@@ -1061,11 +1069,8 @@ func typeSetBit(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
 }
 
 func typeCover(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
-	if len(args) == 0 {
-		return nil, nil
-	}
-	n, err := strconv.ParseUint(args[0], 0, 64)
-	if err != nil {
+	n, errored := getUintImm(args)
+	if errored {
 		return nil, nil
 	}
 	depth := int(n) + 1
@@ -1092,11 +1097,8 @@ func typeCover(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
 }
 
 func typeUncover(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
-	if len(args) == 0 {
-		return nil, nil
-	}
-	n, err := strconv.ParseUint(args[0], 0, 64)
-	if err != nil {
+	n, errored := getUintImm(args)
+	if errored {
 		return nil, nil
 	}
 	depth := int(n) + 1
@@ -1131,16 +1133,13 @@ func typeTxField(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) 
 }
 
 func typeStore(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
-	if len(args) == 0 {
-		return nil, nil
-	}
-	n, err := strconv.ParseUint(args[0], 0, 64)
-	if err != nil {
+	n, errored := getUintImm(args)
+	if errored {
 		return nil, nil
 	}
 	scratchIndex := int(n)
 	top := len(pgm.stack) - 1
-	if top >= 0 && scratchIndex < 256 && scratchIndex >= 0 {
+	if top >= 0 {
 		pgm.scratchSpace[scratchIndex] = pgm.stack[top]
 	}
 	return nil, nil
@@ -1148,28 +1147,23 @@ func typeStore(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
 
 func typeStores(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
 	top := len(pgm.stack) - 1
-	if top >= 0 {
-		for i := range pgm.scratchSpace {
-			if pgm.scratchSpace[i] != pgm.stack[top] {
-				pgm.scratchSpace[i] = StackAny
-			}
+	if top < 0 {
+		return nil, nil
+	}
+	for i := range pgm.scratchSpace {
+		if pgm.scratchSpace[i] != pgm.stack[top] {
+			pgm.scratchSpace[i] = StackAny
 		}
 	}
 	return nil, nil
 }
 
 func typeLoad(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes) {
-	if len(args) == 0 {
-		return nil, nil
-	}
-	n, err := strconv.ParseUint(args[0], 0, 64)
-	if err != nil {
+	n, errored := getUintImm(args)
+	if errored {
 		return nil, nil
 	}
 	scratchIndex := int(n)
-	if scratchIndex < 0 || scratchIndex > 255 {
-		return nil, nil
-	}
 	return nil, StackTypes{pgm.scratchSpace[scratchIndex]}
 }
 

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2411,6 +2411,8 @@ func TestScratchTypeCheck(t *testing.T) {
 	testProg(t, "int 0; loads; btoi", AssemblerMaxVersion, Expect{3, "btoi arg 0..."})
 	// Stores should only set slots to StackAny if they are not the same type as what is being stored
 	testProg(t, "byte 0x01; store 0; int 3; byte 0x01; stores; load 0; int 1; +", AssemblerMaxVersion, Expect{8, "+ arg 0..."})
+	testProg(t, "txn TypeEnum; bnz label1; byte 0x01; label1:; load 0; int 1; +", AssemblerMaxVersion)
+	testProg(t, "txn TypeEnum; bnz label1; byte 0x01; store 0; label1:; load 0; int 1; +", AssemblerMaxVersion)
 }
 
 func TestCoverAsm(t *testing.T) {

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2400,6 +2400,12 @@ func TestSetBitTypeCheck(t *testing.T) {
 	testProg(t, "byte 0x1234; int 2; int 3; setbit; !", AssemblerMaxVersion, Expect{5, "! arg 0..."})
 }
 
+func TestScratchTypeCheck(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+	testProg(t, "byte 0x01; store 0; load 0; int 1; +", AssemblerMaxVersion, Expect{5, "+ arg 0..."})
+}
+
 func TestCoverAsm(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2409,6 +2409,8 @@ func TestScratchTypeCheck(t *testing.T) {
 	testProg(t, "byte 0x01; store 0; load 0; int 1; +", AssemblerMaxVersion, Expect{5, "+ arg 0..."})
 	// Loads should know the type it's loading if all the slots are the same type
 	testProg(t, "int 0; loads; btoi", AssemblerMaxVersion, Expect{3, "btoi arg 0..."})
+	// Loads doesn't know the type when slot types vary
+	testProg(t, "byte 0x01; store 0; int 1; loads; btoi", AssemblerMaxVersion)
 	// Stores should only set slots to StackAny if they are not the same type as what is being stored
 	testProg(t, "byte 0x01; store 0; int 3; byte 0x01; stores; load 0; int 1; +", AssemblerMaxVersion, Expect{8, "+ arg 0..."})
 	// ScratchSpace should reset after hitting label in deadcode

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2403,7 +2403,14 @@ func TestSetBitTypeCheck(t *testing.T) {
 func TestScratchTypeCheck(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
+	// All scratch slots should start as uint64
+	testProg(t, "load 0; int 1; +", AssemblerMaxVersion)
+	// Check load and store accurately using the scratch space
 	testProg(t, "byte 0x01; store 0; load 0; int 1; +", AssemblerMaxVersion, Expect{5, "+ arg 0..."})
+	// Loads should know the type it's loading if all the slots are the same type
+	testProg(t, "int 0; loads; btoi", AssemblerMaxVersion, Expect{3, "btoi arg 0..."})
+	// Stores should only set slots to StackAny if they are not the same type as what is being stored
+	testProg(t, "byte 0x01; store 0; int 3; byte 0x01; stores; load 0; int 1; +", AssemblerMaxVersion, Expect{8, "+ arg 0..."})
 }
 
 func TestCoverAsm(t *testing.T) {

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2411,8 +2411,14 @@ func TestScratchTypeCheck(t *testing.T) {
 	testProg(t, "int 0; loads; btoi", AssemblerMaxVersion, Expect{3, "btoi arg 0..."})
 	// Stores should only set slots to StackAny if they are not the same type as what is being stored
 	testProg(t, "byte 0x01; store 0; int 3; byte 0x01; stores; load 0; int 1; +", AssemblerMaxVersion, Expect{8, "+ arg 0..."})
-	testProg(t, "txn TypeEnum; bnz label1; byte 0x01; label1:; load 0; int 1; +", AssemblerMaxVersion)
-	testProg(t, "txn TypeEnum; bnz label1; byte 0x01; store 0; label1:; load 0; int 1; +", AssemblerMaxVersion)
+	// ScratchSpace should reset after hitting label in deadcode
+	testProg(t, "byte 0x01; store 0; b label1; label1:; load 0; int 1; +", AssemblerMaxVersion)
+	// But it should reset to StackAny not uint64
+	testProg(t, "int 1; store 0; b label1; label1:; load 0; btoi", AssemblerMaxVersion)
+	// Callsubs should also reset the scratch space
+	testProg(t, "callsub A; load 0; btoi; return; A: byte 0x01; store 0; retsub", AssemblerMaxVersion)
+	// But the scratchspace should still be tracked after the callsub
+	testProg(t, "callsub A; int 1; store 0; load 0; btoi; return; A: retsub", AssemblerMaxVersion, Expect{5, "btoi arg 0..."})
 }
 
 func TestCoverAsm(t *testing.T) {

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -443,8 +443,8 @@ var OpSpecs = []OpSpec{
 	{0x32, "global", opGlobal, proto(":a"), 1, field("f", &GlobalFields)},
 	{0x33, "gtxn", opGtxn, proto(":a"), 1, immediates("t", "f").field("f", &TxnScalarFields)},
 	{0x33, "gtxn", opGtxn, proto(":a"), 2, immediates("t", "f").field("f", &TxnFields).assembler(asmGtxn2)},
-	{0x34, "load", opLoad, proto(":a"), 1, immediates("i")},
-	{0x35, "store", opStore, proto("a:"), 1, immediates("i")},
+	{0x34, "load", opLoad, proto(":a"), 1, stacky(typeLoad, "i")},
+	{0x35, "store", opStore, proto("a:"), 1, stacky(typeStore, "i")},
 	{0x36, "txna", opTxna, proto(":a"), 2, immediates("f", "i").field("f", &TxnArrayFields)},
 	{0x37, "gtxna", opGtxna, proto(":a"), 2, immediates("t", "f", "i").field("f", &TxnArrayFields)},
 	// Like gtxn, but gets txn index from stack, rather than immediate arg
@@ -458,8 +458,8 @@ var OpSpecs = []OpSpec{
 	{0x3d, "gaids", opGaids, proto("i:i"), 4, only(modeApp)},
 
 	// Like load/store, but scratch slot taken from TOS instead of immediate
-	{0x3e, "loads", opLoads, proto("i:a"), 5, opDefault()},
-	{0x3f, "stores", opStores, proto("ia:"), 5, opDefault()},
+	{0x3e, "loads", opLoads, proto("i:a"), 5, stacky(typeLoads)},
+	{0x3f, "stores", opStores, proto("ia:"), 5, stacky(typeStores)},
 
 	{0x40, "bnz", opBnz, proto("i:"), 1, opBranch()},
 	{0x41, "bz", opBz, proto("i:"), 2, opBranch()},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
This PR will allow us to error on things of the sort:
"byte 0x01; store 0; int 1; load 0; +" 
by keeping track of the scratch space as we assemble the program within each basic block.
<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan
Load/Store: Tested to make sure a load in the first block puts a uint64 on the stack and that load puts the type of whatever was last stored in that slot if a store was done in that block

Loads/Stores: Added test for loads when all the slots are the same type and put in a test for stores which makes sure it only sets slots to StackAny if the type is not the same as what's on the stack
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
