### PR TITLE
Simplify things by lexing ";" in fieldsFromLine

### DIFF
--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -3532,8 +3532,7 @@ func benchmarkBasicProgram(b *testing.B, source string) {
 func benchmarkOperation(b *testing.B, prefix string, operation string, suffix string) {
 	runs := 1 + b.N/2000
 	inst := strings.Count(operation, ";") + strings.Count(operation, "\n")
-	source := prefix + ";" + strings.Repeat(operation+";", 2000) + ";" + suffix
-	source = strings.ReplaceAll(source, ";", "\n")
+	source := prefix + ";" + strings.Repeat(operation+"\n", 2000) + ";" + suffix
 	ops := testProg(b, source, AssemblerMaxVersion)
 	evalLoop(b, runs, ops.Program)
 	b.ReportMetric(float64(inst), "extra/op")


### PR DESCRIPTION
See if you like it.

The main idea was move semi-colon processing into `fieldsFromLine` as that feels like the right place to be looking at the input character by character.  Has the nice advantage of simplifying processFields, and allowing ';' to split tokens, rather than requiring a space afterward.

I also removed some duplicate line processing from before the `processFields` loop.  Does that seem good?

It's slightly bigger than it needs to be (sorry) because I fixed a typo, and I made the "set" map use a bool instead of int.

Also fixed a wild, ancient bug:
byte base64 base64 //comment
was not broken up right, because the base64 bytes were "base64"!